### PR TITLE
#evaluate now accepts a fn and ars vs a  string

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,52 +78,52 @@ Launches a new instance, which can begin to immediately work if there's a queue 
 ## Browser API
 
 #### navigate: Function(url: string, opts: object): Promise<void>
-```
+```js
 await chrome.navigate('http://www.cnn.com');
 ```
 Navigates the browser to a particular URL. Can supply a second argument, which is a hash that currently supports only `onload`, fired when the browsers `window.onload` event takes place.
 
-#### evaluate: Function(expression: string): Promise<any>
+#### evaluate: Function(expression: function, ...args?: array<any>): Promise<any>
+```js
+await chrome.evaluate(() => window.location.href); // http://cnn.com
 ```
-await chrome.evaluate('window.location.href'); // http://cnn.com
-```
-Evaluates the script and returns the output of the last statement. The result is a meta-object containing the output plus some meta-data about the result. Currently the expression _must_ be a string, but we're investigating ways to make it a bare function to execute.
+Executes the function and returns its value. You can optionally add any number of arguments needed for your function to execute. This happens in a _separate_ context from Node, so you must pass in all parameters that the function needs in the `#evaluate` call. IE: `chrome.evaluate((selector) => document.querySelector(selector), '.buy-now')`
 
 #### screenShot: Function(filePath: string): Promise<any>
-```
+```js
 await chrome.screenShot('/Users/me/Downloads/site.png');
 ```
 Saves a PNG of the current page's viewport. file-path should be the absolute-path where this file will will be saved.
 
 #### pdf: Function(filePath: string): Promise<any>
-```
+```js
 await chrome.pdf('/Users/me/Downloads/site.pdf');
 ```
 Saves a PDF of the current page. file-path should be the absolute-path where this file will will be saved.
 
 #### setWindowSize: Function(width: number, height: number): Promise<any>
-```
+```js
 await chrome.setWindowSize(960, 320);
 ```
 
 Sets the window size of the browser by width and height.
 
 #### exists: Function(selector: string): Promise<boolean>
-```
+```js
 await chrome.exists('.my-button'); // true
 ```
 
 Accepts a `querySelector` css-string (example: chrome.exists('.some-class')), and returns a boolean if the selector exists on the page.
 
 #### getHTML: Function(selector: string): Promise<string>
-```
+```js
 await chrome.getHTML('.my-button'); // <button class="my-button">Click Me!</button>
 ```
 
 Accepts a `querySelector` css-string (example: chrome.exists('.some-class')), and the HTML of the node.
 
 #### trigger: Function(event: string, selector: string): Promise<string>
-```
+```js
 await chrome.trigger('click', '.my-button'); // Clicks => <button class="my-button">Click Me!</button>
 ```
 

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -88,11 +88,14 @@ Use the `Chrome` constructor to navigate to a page and run some custom javascrip
 ```js
 const { Chrome } = require('navalia');
 const chrome = new Chrome();
+const buyButton = 'button.buy-now';
 
 async function getTitle() {
   await chrome.launch();
   await chrome.navigate('http://www.reddit.com/');
-  const res = await chrome.evaluate('document.querySelector("title").text;');
+  const res = await chrome.evaluate((selector) => {
+    return document.querySelector(selector);
+  }, buyButton);
   console.log(res);
 }
 getTitle();


### PR DESCRIPTION
Annotating API language, `evaluate` now accepts a fn and args (Navalia stringifies it for CDP's expression syntax).