### PR TITLE
Feature/pageload run returns promise

### DIFF
--- a/docs/_docs/Chrome/pageload.md
+++ b/docs/_docs/Chrome/pageload.md
@@ -1,0 +1,42 @@
+---
+title: .pageload
+category: Chrome
+---
+
+The `pageload` returns a promise that is resolved when the pageload event is fired. This can be effectively used to block further actions until a pageload has hit (for instance multi-page workflows).
+
+> The below example is pretty elaborate, but serves to demonstrate how to effectively use the pageload method
+
+*JavaScript*
+```js
+const { Chrome } = require('navalia');
+const chrome = new Chrome();
+
+chrome.goto('https://duckduckgo.com/');
+  .then(() => chrome.type('input[type="text"]', 'navalia github'))
+  .then(() => chrome.click('#search_button_homepage'))
+  .then(() => chrome.pageload()) // Wait for the new page to load before proceedin)
+  .then(() => chrome.wait('#links > .result'))
+  .then(() => chrome.html('h2 a'))
+  .then((firstLink) => console.log(`First link is: ${firstLink}`))
+  .then(() => chrome.done());
+```
+
+*TypeScript*
+```ts
+import { Chrome } from 'navalia';
+const chrome = new Chrome();
+
+async function checkPageRank() {
+  await chrome.goto('https://duckduckgo.com/');
+  await chrome.type('input[type="text"]', 'navalia github');
+  await chrome.click('#search_button_homepage');
+  await chrome.pageload(); // Wait for the new page to load before proceeding
+  await chrome.wait('#links > .result');
+  const firstLink = await chrome.html('h2 a');
+  console.log(`First link is: ${firstLink}`);
+  return chrome.done();
+}
+
+checkPageRank();
+```

--- a/docs/_docs/navalia/kill.md
+++ b/docs/_docs/navalia/kill.md
@@ -1,0 +1,68 @@
+---
+title: .kill
+category: Navalia
+order: 3
+---
+
+The `kill` method is used to shut-down Navalia. Any running jobs will be immediately closed, so it's important to ensure all your current work is captured and completed before calling `kill`.
+
+*JavaScript*
+```js
+const { Navalia } = require('navalia');
+const navalia = new Navalia();
+
+navalia
+.run((chrome) => chrome.navigate('http://joelgriffith.net'))
+.then(() => navalia.kill());
+```
+
+*TypeScript*
+```ts
+import { Navalia } from 'navalia';
+const navalia:Navalia = new Navalia();
+
+async function visitMe() {
+  await navalia.run(async (chrome) => chrome.navigate('http://joelgriffith.net'));
+  navalia.kill();
+}
+```
+
+> You can also run multiple jobs in parallel.
+
+*JavaScript*
+```js
+const { Navalia } = require('navalia');
+const navalia = new Navalie();
+
+Promise.all([
+  navalia.run((chrome) => {
+    return chrome.navigate('http://joelgriffith.net');
+  }),
+
+  navalia.run((chrome) => {
+    return chrome.navigate('https://news.ycombinator.net');
+  }),
+]).then(() => navalia.kill());
+```
+
+*TypeScript*
+```ts
+import { Navalia } from 'navalia';
+const navalia:Navalia = new Navalia();
+
+async function doJobs() {
+  await Promise.all([
+    navalia.run(async (chrome) => {
+      return chrome.navigate('http://joelgriffith.net');
+    }),
+
+    navalia.run(async (chrome) => {
+      return chrome.navigate('https://news.ycombinator.net');
+    }),
+  ]);
+
+  navalia.kill();
+}
+
+doJobs();
+```

--- a/docs/_docs/navalia/run.md
+++ b/docs/_docs/navalia/run.md
@@ -6,14 +6,16 @@ order: 2
 
 The run method is used to queue jobs. The run function simply takes a `function` that will be called with one argument: `chrome` which is an instance of `Chrome`, and contains the browser-api. This method also takes care of cleanup, so there's no need to call any done methods in this workflow.
 
+> Run will return a promise if you need to do further orchestration, or react to a job that has completed.
+
 *JavaScript*
 ```js
 const { Navalia } = require('navalia');
 const navalia = new Navalia();
 
-navalia.run((chrome) => {
-  return chrome.navigate('http://joelgriffith.net');
-});
+navalia
+  .run((chrome) => chrome.navigate('http://joelgriffith.net'))
+  .then(() => console.log('Page visited!'));
 ```
 
 *TypeScript*
@@ -21,9 +23,12 @@ navalia.run((chrome) => {
 import { Navalia } from 'navalia';
 const navalia:Navalia = new Navalia();
 
-navalia.run(async (chrome) =>
-  chrome.navigate('http://joelgriffith.net')
-);
+async function visitPages() {
+  await navalia.run(async (chrome) => chrome.navigate('http://joelgriffith.net'));
+  console.log('Complete!');
+}
+
+visitPages();
 ```
 
 > You can also run multiple jobs in parallel.

--- a/src/Navalia.ts
+++ b/src/Navalia.ts
@@ -140,6 +140,11 @@ export class Navalia {
     }
   }
 
+  public async kill(): Promise<void[]> {
+    log(`:kill() > killing all instances regardless of work-in-progress`);
+    return Promise.all(this.chromeInstances.map((chrome) => chrome.quit()));
+  }
+
   public run(handler: jobFunc): Promise<any> {
     return new Promise((resolve, reject) => {
       if (!this.chromeInstances.length || this.chromeInstances.every(isBusy)) {

--- a/src/util/chrome.ts
+++ b/src/util/chrome.ts
@@ -35,13 +35,21 @@ export const defaultFlags:flags = {
 
 // Contains all the business 
 export const launch = async(flags: flags, isHost: boolean = false): Promise<chromeInstance> => {
+  const logLevel:string = process.env.DEBUG && (
+    process.env.DEBUG.includes('ChromeLauncher') ||
+    process.env.DEBUG.includes('*')
+  ) ? 'info' : 'silent';
+
   const chromeFlags:string[] = _.chain(flags)
     .pickBy((value) => value)
     .map((_value, key) => `--${_.kebabCase(key)}`)
     .value();
 
   // Boot Chrome
-  const browser:chromeLauncher.LaunchedChrome = await chromeLauncher.launch({ chromeFlags });
+  const browser:chromeLauncher.LaunchedChrome = await chromeLauncher.launch({
+    chromeFlags,
+    logLevel,
+  });
 
   const cdp = isHost ? 
     await CDP({ target: `ws://localhost:${browser.port}/devtools/browser` }) :


### PR DESCRIPTION
New `.pageload` method on the browser-api. `Navalia.kill` will close down the browser-balancer and `Navalia.run` will return a `then`able suitable for async orchestrating/tests. Lots more still to come