### PR TITLE
Links to external write-ups, screenshot features

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 
 Automate and scale browser workflows with a sane API. Navalia exports a handy `Navalia` module that acts as browser-load balancer, as well as a `Chrome` module that you can use for an easier experience.
 
+## Usage
+
+- [Functional Testing](https://codeburst.io/composable-end-to-end-tests-for-react-apps-2ec82170af62)
+
+- [Website Code Coverage](https://codeburst.io/capturing-unused-application-code-2b7594a9fe06)
+
 **BETA WARNING**
 This project heavily relies on bleeding-edge technology, as such the API and internals will likely change from time to time. I heavily recommend that you install `Chrome Canary` to capture the latest and greatest the browser has to offer.
 

--- a/src/Chrome.ts
+++ b/src/Chrome.ts
@@ -234,11 +234,7 @@ export class Chrome extends EventEmitter {
     return null;
   }
 
-  public async screenshot(filePath: string): Promise<any> {
-    if (!path.isAbsolute(filePath)) {
-      throw new Error(`Filepath is not absolute: ${filePath}`);
-    }
-
+  public async screenshot(filePath?: string): Promise<void | Buffer> {
     const cdp = await this.getChromeCDP();
 
     log(`:screenshot() > saving screenshot to ${filePath}`);
@@ -246,7 +242,15 @@ export class Chrome extends EventEmitter {
     const base64Image = await cdp.Page.captureScreenshot();
     const buffer = new Buffer(base64Image.data, 'base64');
 
-    return fs.writeFileSync(filePath, buffer, { encoding: 'base64' });
+    if (filePath) {
+      if (!path.isAbsolute(filePath)) {
+        throw new Error(`Filepath is not absolute: ${filePath}`);
+      }
+
+      return fs.writeFileSync(filePath, buffer, { encoding: 'base64' });
+    }
+
+    return buffer;
   }
 
   public async pdf(filePath: string): Promise<any> {


### PR DESCRIPTION
Linking out to external how-to's. `screenshot` now returns a `Buffer` when no path is provided for consumers to do with as they please.