### PR TITLE
.text api for sucking out text from a element

### DIFF
--- a/docs/_docs/Chrome/text.md
+++ b/docs/_docs/Chrome/text.md
@@ -1,0 +1,32 @@
+---
+title: .text
+category: Chrome
+---
+
+The `text` method returns the inside-text of a DOM node (including its children's text) as a string. It accepts one argument: a css-selector string, and defaults to `body` when none is present.
+
+*JavaScript*
+```js
+const { Chrome } = require('navalia');
+const chrome = new Chrome();
+
+chrome.goto('https://www.google.com')
+.then(() => chrome.text('title'))
+.then((result) => console.log(res)) // Google
+.then(() => chrome.done());
+```
+
+*TypeScript*
+```ts
+import { Chrome } from 'navalia';
+const chrome = new Chrome();
+
+async function html() {
+  await chrome.goto('https://www.google.com');
+  const result = await chrome.text('title');
+  console.log(result); // Google
+  chrome.done();
+}
+
+html();
+```

--- a/src/Chrome.ts
+++ b/src/Chrome.ts
@@ -204,7 +204,7 @@ export class Chrome extends EventEmitter {
     const script = `
       (() => {
         const result = (${String(expression)}).apply(null, ${JSON.stringify(args)});
-        if (result.then) {
+        if (result && result.then) {
           result.catch((error) => { throw new Error(error); });
           return result;
         }
@@ -301,6 +301,20 @@ export class Chrome extends EventEmitter {
     const { outerHTML } = await cdp.DOM.getOuterHTML({ nodeId });
 
     return outerHTML;
+  }
+
+  public async text(selector: string = 'body'): Promise<string | null> {
+    log(`:text() > getting '${selector}' text`);
+    
+    const text = await this.evaluate((selector) => {
+      const ele = document.querySelector(selector);
+      if (ele) {
+        return ele.textContent;
+      }
+      return null;
+    }, selector);
+
+    return text;
   }
 
   public async fetch(...args): Promise<any> {


### PR DESCRIPTION
Adds a `.text` api for returning a DOM node's inner-text (minus all the HTML markup)