### PR TITLE
goto bugs, wait-for automatically, logging, throwing, and more

### DIFF
--- a/docs/_docs/Chrome/attr.md
+++ b/docs/_docs/Chrome/attr.md
@@ -5,6 +5,10 @@ category: Chrome
 
 The `attr` method operates similarly to the [jQuery `attr` method](http://api.jquery.com/attr/), and return the value of an attribute of a DOM element. It's called with 2 parameters: the css-style selector of the element you wish to query, and the attribute you want to retrieve.
 
+Accepts a 3rd parameter of options for granular control: `wait`, a boolean to inform Chrome to wait for it's apperance before executing (defaults to `true`), and a `timeout` number in milliseconds to throw when it doesn't appear.
+
+Returns the attribute (`string`) or `null` if not found.
+
 *JavaScript*
 ```js
 const { Chrome } = require('navalia');

--- a/docs/_docs/Chrome/check.md
+++ b/docs/_docs/Chrome/check.md
@@ -5,6 +5,10 @@ category: Chrome
 
 The `check` method checks a checkbox. It accepts a single argument: the css-style selector of the checkbox you want to check
 
+Accepts a 2nd parameter of options for granular control: `wait`, a boolean to inform Chrome to wait for it's apperance before executing (defaults to `true`), and a `timeout` number in milliseconds to throw when it doesn't appear.
+
+Returns a `boolean` indicating success.
+
 *JavaScript*
 ```js
 const { Chrome } = require('navalia');

--- a/docs/_docs/Chrome/evaluate.md
+++ b/docs/_docs/Chrome/evaluate.md
@@ -5,7 +5,7 @@ category: Chrome
 
 The async `evaluate` method accepts a function, and an optional set of arguments, to run inside of the Chrome JavaScript evironment. It's important to highlight that any arguments or other references _must_ be passed in as an argument (things like closures won't work). This is due to the fact that the function gets injected into the Chrome runtime, which requires everything to be serialzed.
 
-Evaluate returns the result of the function, or an Error instance if the script throws. If no value is returned, the method will simply return `null`.
+Evaluate returns the result of the function, or throws if there's an issue.
 
 > You can also execute async functions. Navalia will handle them as long as they return a 'then`-able
 

--- a/docs/_docs/Chrome/exists.md
+++ b/docs/_docs/Chrome/exists.md
@@ -5,6 +5,10 @@ category: Chrome
 
 The `exists` method returns if the Element selector exists on the page. Accepts a `string` of a css-style selector.
 
+Accepts a 2nd parameter of options for granular control: `wait`, a boolean to inform Chrome to wait for it's apperance before executing (defaults to `true`), and a `timeout` number in milliseconds to throw when it doesn't appear.
+
+Returns a `boolean` indicating existence.
+
 *JavaScript*
 ```js
 const { Chrome } = require('navalia');

--- a/docs/_docs/Chrome/focus.md
+++ b/docs/_docs/Chrome/focus.md
@@ -5,6 +5,8 @@ category: Chrome
 
 The `focus` method focuses an element on the page. It accepts a css-style selector of the element you wish to focus.
 
+Accepts a 2nd parameter of options for granular control: `wait`, a boolean to inform Chrome to wait for it's apperance before executing (defaults to `true`), and a `timeout` number in milliseconds to throw when it doesn't appear.
+
 > It's not necessary to focus prior to entering text
 
 *JavaScript*

--- a/docs/_docs/Chrome/goto.md
+++ b/docs/_docs/Chrome/goto.md
@@ -3,7 +3,7 @@ title: .goto
 category: Chrome
 ---
 
-The async `goto` method navigates Chrome to a webpage. By default, it waits for the pageload event, but can be overriden. Below is an example of going to google.com.
+The async `goto` method navigates Chrome to a webpage. By default, it waits for the pageload event, but can be overriden. `goto` considers practically any response a success, except for network errors or timeouts. Redirects and other mechanisms for navigation are considered successful.
 
 *JavaScript*
 ```js

--- a/docs/_docs/Chrome/html.md
+++ b/docs/_docs/Chrome/html.md
@@ -5,6 +5,10 @@ category: Chrome
 
 The `html` method returns the string of HTML for a particular selector. It accepts one argument: a css-style selector for the element you wish to extract html from.
 
+Accepts a 2nd parameter of options for granular control: `wait`, a boolean to inform Chrome to wait for it's apperance before executing (defaults to `true`), and a `timeout` number in milliseconds to throw when it doesn't appear.
+
+Returns the HTML as a `string`.
+
 *JavaScript*
 ```js
 const { Chrome } = require('navalia');

--- a/docs/_docs/Chrome/inject.md
+++ b/docs/_docs/Chrome/inject.md
@@ -5,7 +5,7 @@ category: Chrome
 
 The `inject` method injects a JavaScript or CSS file into the page. It accpets a single-argument: a string of the filepath to inject.
 
-It will return a `boolean` indicating succes.
+It will return a `boolean` indicating succes, or throw on failure.
 
 *JavaScript*
 ```js

--- a/docs/_docs/Chrome/pageload.md
+++ b/docs/_docs/Chrome/pageload.md
@@ -5,7 +5,7 @@ category: Chrome
 
 The `pageload` returns a promise that is resolved when the pageload event is fired. This can be effectively used to block further actions until a pageload has hit (for instance multi-page workflows).
 
-> The below example is pretty elaborate, but serves to demonstrate how to effectively use the pageload method
+> Note: nearly all methods will await pageload before executing, so it's not necessary to call this between page-transition events (IE: clicking an anchor).
 
 *JavaScript*
 ```js

--- a/docs/_docs/Chrome/pdf.md
+++ b/docs/_docs/Chrome/pdf.md
@@ -3,7 +3,7 @@ title: .pdf
 category: Chrome
 ---
 
-The `pdf` method takes a single argument: a file-path (absolute) of where to save the pdf.
+The `pdf` method takes a single argument: a file-path (absolute) of where to save the pdf. If no file-path is provided it will return a buffer of base64 encoded data.
 
 *JavaScript*
 ```js

--- a/docs/_docs/Chrome/save.md
+++ b/docs/_docs/Chrome/save.md
@@ -3,9 +3,9 @@ title: .save
 category: Chrome
 ---
 
-The `save` method captures the webpage HTML and saves it to the provided location. It accepts a single arugment: the absolute-path of where to save the file.
+The `save` method captures the webpage HTML and saves it to the provided location. It accepts a single arugment: the absolute-path of where to save the file. If no file-path is provided, the `save` method will return a string of the page.
 
-> This method can be used to snapshot pages for SEO purposes
+> This method can be used to snapshot pages for SEO purposes.
 
 *JavaScript*
 ```js

--- a/docs/_docs/Chrome/screenshot.md
+++ b/docs/_docs/Chrome/screenshot.md
@@ -3,7 +3,9 @@ title: .screenshot
 category: Chrome
 ---
 
-The `screenshot` method takes an optional single argument: a file-path (absolute) of where to save the screenshot. If no filepath is supplied the method will return a `Buffer` of `base64` encoded data.
+The `screenshot` method takes an optional single argument: a file-path (absolute) of where to save the screenshot.
+
+If no filepath is supplied the method will return a `Buffer` of `base64` encoded data.
 
 > The screenshot method generates a png file.
 

--- a/docs/_docs/Chrome/select.md
+++ b/docs/_docs/Chrome/select.md
@@ -5,6 +5,10 @@ category: Chrome
 
 The `select` method selects an option inside a dropdown selector. It accepts two arguments: the css-style selector of the dropdown you want to select, and the option you wish to select.
 
+Accepts a 2nd parameter of options for granular control: `wait`, a boolean to inform Chrome to wait for it's apperance before executing (defaults to `true`), and a `timeout` number in milliseconds to throw when it doesn't appear.
+
+Returns a boolean indicating success.
+
 *JavaScript*
 ```js
 const { Chrome } = require('navalia');

--- a/docs/_docs/Chrome/size.md
+++ b/docs/_docs/Chrome/size.md
@@ -7,6 +7,8 @@ The `size` method resizes the frame of the browser, and is suitable for capturin
 
 The `size` method takes two arguments: a `width` (number) and a `height` (number).
 
+Returns `true` indicating success.
+
 *JavaScript*
 ```js
 const { Chrome } = require('navalia');

--- a/docs/_docs/Chrome/text.md
+++ b/docs/_docs/Chrome/text.md
@@ -5,6 +5,10 @@ category: Chrome
 
 The `text` method returns the inside-text of a DOM node (including its children's text) as a string. It accepts one argument: a css-selector string, and defaults to `body` when none is present.
 
+Accepts a 2nd parameter of options for granular control: `wait`, a boolean to inform Chrome to wait for it's apperance before executing (defaults to `true`), and a `timeout` number in milliseconds to throw when it doesn't appear.
+
+Returns a string of text inside the element.
+
 *JavaScript*
 ```js
 const { Chrome } = require('navalia');

--- a/docs/_docs/Chrome/type.md
+++ b/docs/_docs/Chrome/type.md
@@ -5,6 +5,10 @@ category: Chrome
 
 The `type` method allows you to type text into an element. It accepts two arguments: the css-style selector of the element you want to enter text into, and a string of text to input.
 
+Accepts a 3rd parameter of options for granular control: `wait`, a boolean to inform Chrome to wait for it's apperance before executing (defaults to `true`), and a `timeout` number in milliseconds to throw when it doesn't appear.
+
+Returns a `boolean` indicating success.
+
 > It's not necessary to focus prior to entering text
 
 *JavaScript*

--- a/docs/_docs/Chrome/uncheck.md
+++ b/docs/_docs/Chrome/uncheck.md
@@ -3,7 +3,11 @@ title: .uncheck
 category: Chrome
 ---
 
-The `uncheck` method un-checks a checkbox. It accepts a single argument: the css-style selector of the checkbox you want to un-check
+The `uncheck` method un-checks a checkbox. It accepts a single argument: the css-style selector of the checkbox you want to un-check.
+
+Accepts a 2nd parameter of options for granular control: `wait`, a boolean to inform Chrome to wait for it's apperance before executing (defaults to `true`), and a `timeout` number in milliseconds to throw when it doesn't appear.
+
+Returns a `boolean` indicating success.
 
 *JavaScript*
 ```js

--- a/docs/_docs/Chrome/visible.md
+++ b/docs/_docs/Chrome/visible.md
@@ -5,6 +5,10 @@ category: Chrome
 
 The `visible` method returns a boolean indiciating if an element is visible. It accepts a single argument: the css-style of the selector you want to check.
 
+Accepts a 2nd parameter of options for granular control: `wait`, a boolean to inform Chrome to wait for it's apperance before executing (defaults to `true`), and a `timeout` number in milliseconds to throw when it doesn't appear.
+
+Returns a `boolean` indicating item is viewable.
+
 *JavaScript*
 ```js
 const { Chrome } = require('navalia');

--- a/docs/_docs/Chrome/wait.md
+++ b/docs/_docs/Chrome/wait.md
@@ -5,7 +5,7 @@ category: Chrome
 
 The `wait` method accepts either a selector to wait for, or time in MS, before allowing Chrome to continue execution. If a string is passed in it's assumed to be a selector, whilst a number indicates a time to wait.
 
-> When using a selector, Navalia will fail after waiting for 10 seconds
+> When using a selector, a 2nd parameter of max-time to wait can be passed. Defaults to 10 seconds
 
 ### Using a selector
 

--- a/docs/_docs/chrome/constructor.md
+++ b/docs/_docs/chrome/constructor.md
@@ -12,6 +12,28 @@ It's important to call `done` at the end of your script so that the browser exis
 
 > You can view the chrome logs by setting the DEBUG environment variable to contain 'navalia:chrome' > `DEBUG=navalia:chrome node my-script.js`
 
+### timeout
+
+A time in milliseconds to use as a default for various asyncronous actions. This generally effects most DOM API's, where Chrome will wait for a selector before executing.
+
+*JavaScript*
+```js
+const { Chrome } = require('navalia');
+
+const chrome = new Chrome({
+  timeout: 60000,
+});
+```
+
+*TypeScript*
+```ts
+import { Chrome } from 'navalia';
+
+// Translates to `chrome --disable-sync --headless`
+const chrome:Chrome = new Chrome({
+  timeout: 60000,
+});
+
 ### flags
 
 An optional parameter of flags to pass the chrome execution. This should be a hash of `parameter: boolean`. By default, Chrome will boot with these flags: `--headless --disable-gpu --hide-scrollbars`. If you wish to disables these, you can do by setting them to `false` in the constructor.

--- a/src/Chrome.ts
+++ b/src/Chrome.ts
@@ -229,7 +229,7 @@ export class Chrome extends EventEmitter {
 
       cdp.Network.requestWillBeSent(params => {
         if (requestId) return;
-        if (params.documentURL === url) {
+        if (params.documentURL.includes(url)) {
           requestId = params.requestId;
         }
       });

--- a/src/Chrome.ts
+++ b/src/Chrome.ts
@@ -41,7 +41,7 @@ export const pageloadOpts = {
 };
 
 const defaultDomOpts: domOpts = {
-  wait: false,
+  wait: true,
 };
 
 // waitForElement is called inside the context
@@ -51,6 +51,10 @@ function waitForElement(selector, timeout) {
     const timeOutId = setTimeout(() => {
       reject(`Selector "${selector}" failed to appear in ${timeout} ms`);
     }, timeout);
+
+    if (document.querySelector(selector)) {
+      return resolve();
+    }
 
     const observer = new MutationObserver(function(_mutations, observation) {
       const found = document.querySelector(selector);

--- a/src/Chrome.ts
+++ b/src/Chrome.ts
@@ -2,23 +2,11 @@ import { EventEmitter } from 'events';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as debug from 'debug';
+
 import * as chromeUtil from './util/chrome';
+import { getPageURL, waitForElement, click, html } from './util/dom';
 
 const log = debug('navalia:chrome');
-
-type triggerEvents =
-  | 'click'
-  | 'mousedown'
-  | 'mouseup'
-  | 'mouseover'
-  | 'touchstart'
-  | 'touchend'
-  | 'focus'
-  | 'touchcancel'
-  | 'touchmove'
-  | 'change'
-  | 'blur'
-  | 'select';
 
 export interface chromeConstructorOpts {
   flags?: chromeUtil.flags;
@@ -31,47 +19,9 @@ export interface domOpts {
   timeout?: number;
 }
 
-export const events = {
-  done: 'done',
-};
-
-export const pageloadOpts = {
-  onload: true,
-  coverage: false,
-};
-
 const defaultDomOpts: domOpts = {
   wait: true,
 };
-
-// waitForElement is called inside the context
-// of the browser, so no typings (just good 'ol JS)
-function waitForElement(selector, timeout) {
-  return new Promise((resolve, reject) => {
-    const timeOutId = setTimeout(() => {
-      reject(`Selector "${selector}" failed to appear in ${timeout} ms`);
-    }, timeout);
-
-    if (document.querySelector(selector)) {
-      return resolve();
-    }
-
-    const observer = new MutationObserver(function(_mutations, observation) {
-      const found = document.querySelector(selector);
-      if (found) {
-        observation.disconnect();
-        clearTimeout(timeOutId);
-        return resolve();
-      }
-    });
-
-    // start observing
-    observer.observe(document, {
-      childList: true,
-      subtree: true,
-    });
-  });
-}
 
 export class Chrome extends EventEmitter {
   private cdp?: chromeUtil.cdp;
@@ -80,6 +30,7 @@ export class Chrome extends EventEmitter {
   private kill: () => Promise<{}>;
   private defaultTimeout: number;
   private navigatingPromise: Promise<any>;
+  private frameId: string;
 
   constructor(opts: chromeConstructorOpts = {}) {
     super();
@@ -109,67 +60,6 @@ export class Chrome extends EventEmitter {
     this.cdp = cdp;
 
     return cdp;
-  }
-
-  private async getSelectorId(selector: string): Promise<number | null> {
-    const cdp = await this.getChromeCDP();
-
-    const document = await cdp.DOM.getDocument();
-
-    const { nodeId } = await cdp.DOM.querySelector({
-      nodeId: document.root.nodeId,
-      selector,
-    });
-
-    return nodeId;
-  }
-
-  private async trigger(
-    eventName: triggerEvents,
-    selector: string,
-  ): Promise<any> {
-    let eventClass = '';
-
-    switch (eventName) {
-      case 'click':
-      case 'mousedown':
-      case 'mouseup':
-      case 'mouseover':
-        eventClass = 'MouseEvents';
-        break;
-
-      case 'touchstart':
-      case 'touchend':
-      case 'touchcancel':
-      case 'touchmove':
-        eventClass = 'TouchEvents';
-        break;
-
-      case 'focus':
-      case 'change':
-      case 'blur':
-      case 'select':
-        eventClass = 'HTMLEvents';
-        break;
-
-      default:
-        throw `chrome#trigger: Couldn't handle event ${eventName} on selector ${selector}.`;
-    }
-
-    const expression = function(selector, eventName, eventClass) {
-      const node = document.querySelector(selector);
-      if (!node) {
-        return false;
-      }
-      const doc = node && node.ownerDocument ? node.ownerDocument : node;
-      const e = doc && doc.createEvent(eventClass);
-      e.initEvent(eventName, true);
-      e.synthetic = true;
-      node.dispatchEvent(e, true);
-      return true;
-    };
-
-    return this.evaluate(expression, selector, eventName, eventClass);
   }
 
   private async runScript(
@@ -205,15 +95,21 @@ export class Chrome extends EventEmitter {
       coverage: boolean;
       onload: boolean;
       timeout?: number;
-    } = pageloadOpts,
+    } = {
+      onload: true,
+      coverage: false,
+    },
   ): Promise<any> {
     const cdp = await this.getChromeCDP();
 
     const waitForPageload = opts.onload === undefined ? true : opts.onload;
     const runCoverage = opts.coverage === undefined ? false : opts.coverage;
 
-    cdp.Page.frameStartedLoading(() => {
-      this.navigatingPromise = cdp.Page.loadEventFired();
+    cdp.Page.frameStartedLoading(({ frameId }) => {
+      if (frameId === this.frameId) {
+        log(':pageload() > page is loading');
+        this.navigatingPromise = cdp.Page.loadEventFired();
+      }
     });
 
     if (runCoverage) {
@@ -262,11 +158,12 @@ export class Chrome extends EventEmitter {
             log(`:goto() > waiting for pageload on ${url}`);
             await cdp.Page.loadEventFired();
           }
-          resolve(await this.evaluate(() => document.location.href));
+          resolve(await this.evaluate(getPageURL));
         }
       });
 
-      cdp.Page.navigate({ url });
+      const { frameId } = await cdp.Page.navigate({ url });
+      this.frameId = frameId;
     });
   }
 
@@ -287,22 +184,17 @@ export class Chrome extends EventEmitter {
       })();
     `;
 
-    log(`:evaluate() > executing script: ${script}`);
+    log(`:evaluate() > executing function '${expression.name}' in Chrome`);
 
     // Always eval scripts as if they were async
     const response = await this.runScript(script, true);
 
-    if (response) {
-      if (response.exceptionDetails) {
-        return new Error(
-          response.exceptionDetails.exception.description ||
-            response.exceptionDetails.text,
-        );
-      }
+    if (response && response.exceptionDetails) {
+      throw new Error(response.exceptionDetails.exception.value);
+    }
 
-      if (response.result) {
-        return response.result.value;
-      }
+    if (response && response.result) {
+      return response.result.value;
     }
 
     return null;
@@ -371,11 +263,12 @@ export class Chrome extends EventEmitter {
     opts: domOpts = defaultDomOpts,
   ): Promise<boolean> {
     await this.navigatingPromise;
-    log(`:exists() > checking if '${selector}' exists`);
 
     if (opts.wait) {
       await this.wait(selector, opts.timeout);
     }
+
+    log(`:exists() > checking if '${selector}' exists`);
 
     return this.evaluate(selector => {
       const ele = document.querySelector(selector);
@@ -388,7 +281,6 @@ export class Chrome extends EventEmitter {
     opts: domOpts = defaultDomOpts,
   ): Promise<string | null> {
     await this.navigatingPromise;
-    const cdp = await this.getChromeCDP();
 
     if (opts.wait) {
       await this.wait(selector, opts.timeout);
@@ -396,37 +288,28 @@ export class Chrome extends EventEmitter {
 
     log(`:html() > getting '${selector}' HTML`);
 
-    const nodeId = await this.getSelectorId(selector);
-
-    if (!nodeId) {
-      return null;
-    }
-
-    const { outerHTML } = await cdp.DOM.getOuterHTML({ nodeId });
-
-    return outerHTML;
+    return this.evaluate(html, selector);
   }
 
   public async text(
     selector: string = 'body',
     opts: domOpts = defaultDomOpts,
-  ): Promise<string | null> {
+  ): Promise<string> {
     await this.navigatingPromise;
-    log(`:text() > getting '${selector}' text`);
 
     if (opts.wait) {
       await this.wait(selector, opts.timeout);
     }
 
-    const text = await this.evaluate(selector => {
-      const ele = document.querySelector(selector);
-      if (ele) {
-        return ele.textContent;
-      }
-      return null;
-    }, selector);
+    log(`:text() > getting '${selector}' text`);
 
-    return text;
+    return this.evaluate(selector => {
+      const ele = document.querySelector(selector);
+      if (!ele) {
+        throw new Error(`:text() > selector ${selector} wasn't found.`);
+      }
+      return ele.textContent;
+    }, selector);
   }
 
   public async fetch(...args): Promise<any> {
@@ -497,9 +380,10 @@ export class Chrome extends EventEmitter {
 
   public async save(filePath?: string): Promise<boolean | string | null> {
     await this.navigatingPromise;
-    log(`:save() > saving page HTML to ${filePath}`);
 
     const html = await this.html();
+
+    log(`:save() > saving page HTML to ${filePath}`);
 
     if (filePath) {
       try {
@@ -520,13 +404,14 @@ export class Chrome extends EventEmitter {
     opts: domOpts = defaultDomOpts,
   ): Promise<boolean> {
     await this.navigatingPromise;
-    log(`:click() > clicking '${selector}'`);
 
     if (opts.wait) {
       await this.wait(selector, opts.timeout);
     }
 
-    return this.trigger('click', selector);
+    log(`:click() > clicking '${selector}'`);
+
+    return this.evaluate(click, selector);
   }
 
   public async focus(
@@ -534,6 +419,7 @@ export class Chrome extends EventEmitter {
     opts: domOpts = defaultDomOpts,
   ): Promise<boolean> {
     await this.navigatingPromise;
+
     const cdp = await this.getChromeCDP();
 
     if (opts.wait) {
@@ -549,7 +435,9 @@ export class Chrome extends EventEmitter {
     });
 
     if (!node) {
-      return false;
+      throw new Error(
+        `:focus() > Couldn't find element '${selector}' on the page.`,
+      );
     }
 
     await cdp.DOM.focus({ nodeId: node.nodeId });
@@ -564,18 +452,14 @@ export class Chrome extends EventEmitter {
   ): Promise<boolean> {
     await this.navigatingPromise;
 
-    log(`:type() > typing'${value}' into '${selector}'`);
-
     if (opts.wait) {
       await this.wait(selector, opts.timeout);
     }
 
     // Focus on the selector
-    const focused = await this.focus(selector);
+    await this.focus(selector, { wait: false });
 
-    if (!focused) {
-      return false;
-    }
+    log(`:type() > typing text '${value}' into '${selector}'`);
 
     const keys = value.split('') || [];
 
@@ -591,11 +475,12 @@ export class Chrome extends EventEmitter {
     opts: domOpts = defaultDomOpts,
   ): Promise<boolean> {
     await this.navigatingPromise;
-    log(`:check() > checking checkbox '${selector}'`);
 
     if (opts.wait) {
       await this.wait(selector, opts.timeout);
     }
+
+    log(`:check() > checking checkbox '${selector}'`);
 
     return this.evaluate(selector => {
       var element = document.querySelector(selector);
@@ -612,22 +497,21 @@ export class Chrome extends EventEmitter {
     opts: domOpts = defaultDomOpts,
   ): Promise<boolean> {
     await this.navigatingPromise;
-    log(`:uncheck() > un-checking checkbox '${selector}'`);
 
     if (opts.wait) {
       await this.wait(selector, opts.timeout);
     }
 
-    await this.evaluate(selector => {
-      var element = document.querySelector(selector);
-      if (element) {
-        element.checked = false;
-        return true;
-      }
-      return false;
-    }, selector);
+    log(`:uncheck() > un-checking checkbox '${selector}'`);
 
-    return true;
+    return this.evaluate(selector => {
+      var element = document.querySelector(selector);
+      if (!element) {
+        throw new Error(`:uncheck() > Couldn't find '${selector}' on page.`);
+      }
+      element.checked = false;
+      return true;
+    }, selector);
   }
 
   public async select(
@@ -636,20 +520,21 @@ export class Chrome extends EventEmitter {
     opts: domOpts = defaultDomOpts,
   ): Promise<boolean> {
     await this.navigatingPromise;
-    log(`:select() > selecting option '${option}' in '${selector}'`);
 
     if (opts.wait) {
       await this.wait(selector, opts.timeout);
     }
 
-    await this.evaluate(selector => {
+    log(`:select() > selecting option '${option}' in '${selector}'`);
+
+    return this.evaluate(selector => {
       var element = document.querySelector(selector);
       if (element) {
         element.value = option;
+        return true;
       }
+      return false;
     }, selector);
-
-    return true;
   }
 
   public async visible(
@@ -657,30 +542,37 @@ export class Chrome extends EventEmitter {
     opts: domOpts = defaultDomOpts,
   ): Promise<boolean> {
     await this.navigatingPromise;
-    log(`:visible() > seeing if '${selector}' is visible`);
 
     if (opts.wait) {
       await this.wait(selector, opts.timeout);
     }
 
+    log(`:visible() > seeing if '${selector}' is visible`);
+
     return this.evaluate(selector => {
       var element = document.querySelector(selector);
-      if (element) {
-        let style;
-        try {
-          style = window.getComputedStyle(element);
-        } catch (e) {
-          return false;
-        }
-        if (style.visibility === 'hidden' || style.display === 'none') {
-          return false;
-        }
-        if (style.display === 'inline' || style.display === 'inline-block') {
-          return true;
-        }
-        return element.offsetWidth > 0 && element.offsetHeight > 0;
+
+      if (!element) {
+        throw new Error(`:visible() > Couldn't find '${selector}' on page.`);
       }
-      return false;
+
+      let style;
+      try {
+        style = window.getComputedStyle(element);
+      } catch (e) {
+        return false;
+      }
+      if (style.visibility === 'hidden' || style.display === 'none') {
+        return false;
+      }
+      if (
+        style.display === 'inline' ||
+        style.display === 'inline-block' ||
+        style.display === 'flex'
+      ) {
+        return true;
+      }
+      return element.offsetWidth > 0 && element.offsetHeight > 0;
     }, selector);
   }
 
@@ -701,7 +593,7 @@ export class Chrome extends EventEmitter {
     timeout = timeout || this.defaultTimeout;
 
     log(
-      `:wait() > waiting for selector "${waitParam}" to be inserted until ${timeout}ms`,
+      `:wait() > waiting for selector "${waitParam}" a maximum of ${timeout}ms`,
     );
 
     await this.evaluate(waitForElement, waitParam, timeout);
@@ -733,9 +625,7 @@ export class Chrome extends EventEmitter {
       return true;
     }
 
-    log(`:inject() > Unknown extension ${extension}`);
-
-    return false;
+    throw new Error(`:inject() > Unknown extension ${extension}`);
   }
 
   public async pageload(): Promise<boolean> {
@@ -781,9 +671,12 @@ export class Chrome extends EventEmitter {
     opts: domOpts = defaultDomOpts,
   ): Promise<string | null> {
     await this.navigatingPromise;
+
     if (opts.wait) {
       await this.wait(selector, opts.timeout);
     }
+
+    log(`:attr() > getting '${selector}' attribute '${attribute}'`);
 
     return this.evaluate(
       (selector, attribute) => {
@@ -802,7 +695,6 @@ export class Chrome extends EventEmitter {
 
   public async coverage(
     src: string,
-    config = { throw: true },
   ): Promise<{ total: number; unused: number; percentUnused: number } | Error> {
     await this.navigatingPromise;
     const cdp = await this.getChromeCDP();
@@ -828,12 +720,7 @@ export class Chrome extends EventEmitter {
     await cdp.CSS.stopRuleUsageTracking();
 
     if (!jsCoverage && !styleSheet) {
-      const error = new Error(`Couldn't locate script ${src} on the page.`);
-      log(`:coverage() > ${src} not found on the page.`);
-      if (config.throw) {
-        throw error;
-      }
-      return error;
+      throw new Error(`Couldn't locate script ${src} on the page.`);
     }
 
     if (styleSheet && styleSheet.styleSheetId) {
@@ -909,6 +796,6 @@ export class Chrome extends EventEmitter {
       this.kill();
     }
 
-    this.emit(events.done);
+    this.emit('done');
   }
 }

--- a/src/util/ChromeHelper.ts
+++ b/src/util/ChromeHelper.ts
@@ -1,7 +1,7 @@
 import * as debug from 'debug';
 
 import * as chromeUtil from './chrome';
-import { Chrome, events } from '../Chrome';
+import { Chrome } from '../Chrome';
 
 const log = debug('navalia:chrome-helper');
 
@@ -69,7 +69,7 @@ export class ChromeHelper {
       timeout: this.defaultTimeout,
     });
 
-    newTab.on(events.done, this.onTabClose.bind(this, targetId));
+    newTab.on('done', this.onTabClose.bind(this, targetId));
 
     return newTab;
   }

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -1,0 +1,54 @@
+export function waitForElement(
+  selector: string,
+  timeout: number,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeOutId = setTimeout(() => {
+      reject(`Selector "${selector}" failed to appear in ${timeout} ms`);
+    }, timeout);
+
+    if (document.querySelector(selector)) return resolve();
+
+    const observer = new MutationObserver(function(_mutations, observation) {
+      const found = document.querySelector(selector);
+      if (found) {
+        observation.disconnect();
+        clearTimeout(timeOutId);
+        return resolve();
+      }
+    });
+
+    // start observing
+    observer.observe(document, {
+      childList: true,
+      subtree: true,
+    });
+  });
+}
+
+export function getPageURL(): string {
+  return document.location.href;
+}
+
+export function click(selector: string): boolean {
+  const element = document.querySelector(selector);
+  if (!element) {
+    throw new Error(
+      `:click() > Unable to find element by selector: ${selector}`,
+    );
+  }
+  const event = document.createEvent('MouseEvent');
+  event.initEvent('click', true, true);
+  element.dispatchEvent(event);
+  return true;
+}
+
+export function html(selector: string): string {
+  const element = document.querySelector(selector);
+  if (!element) {
+    throw new Error(
+      `:html() > Unable to find element by selector: ${selector}`,
+    );
+  }
+  return element.outerHTML;
+}


### PR DESCRIPTION
Lots of cleanup and updates to docs. Here's the high-level:

- `goto` throws on network failures (redirects are considered OK)
- Most DOM methods (`click`, `type`, `exists`...) now default to "waiting" for the respective selectors to appear before executing.
- First stab at also waiting for `pageload`s to hapen before the next "action".
- Most API's now throw if something is remotely odd (elements not there, IE) and return values

Still need to do changelog