### PR TITLE
Fix goto with hash fragment

### DIFF
--- a/src/Chrome.ts
+++ b/src/Chrome.ts
@@ -234,7 +234,7 @@ export class Chrome extends EventEmitter {
 
         cdp.Network.requestWillBeSent(params => {
           if (requestId) return;
-          if (params.documentURL.includes(url)) {
+          if (params.documentURL.includes(url.split('#')[0])) {
             requestId = params.requestId;
           }
         });


### PR DESCRIPTION
When navigating to a url with hash fragment, it isn't caught by the requestWillBeSent event because it checks that it includes the original url while Chrome only shares the url without the hash fragment.
a simple url cut inside the event fixed it for me.